### PR TITLE
"build" added

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3"
 
 services:
   NetWatchSSHAttackPod:
+    build:
+      context: src
     image: netwatch_ssh-attackpod:latest
     container_name: netwatch_ssh-attackpod
     environment:


### PR DESCRIPTION
With this option you can build the image calling  `docker compose build`
see https://docs.docker.com/reference/cli/docker/compose/build/

btw it would be nice if attackpod would be published to [dockerhub](https://hub.docker.com/) instead of having people to wget/load from github releases. 