### PR TITLE
Integration test for docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set DOCKER_IMAGE_TAG env var
       run: echo "DOCKER_IMAGE_TAG=$(date +'%s-snapshot')" >> $GITHUB_ENV
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag netwatch_ssh-attackpod:$DOCKER_IMAGE_TAG
+      run: docker build src/ --tag netwatch_ssh-attackpod:$DOCKER_IMAGE_TAG
     - name: Run python based integration tests via pytest
       env:
         DOCKER_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,10 @@ jobs:
       run: echo "DOCKER_IMAGE_TAG=$(date +'%s-snapshot')" >> $GITHUB_ENV
     - name: Build the Docker image
       run: docker build src/ --tag netwatch_ssh-attackpod:$DOCKER_IMAGE_TAG
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r tests/requirements.txt
     - name: Run python based integration tests via pytest
       env:
         DOCKER_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,24 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch
+#  push:
+#    branches: [ "main" ]
+#  pull_request:
+#    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set DOCKER_IMAGE_TAG env var
+      run: echo "DOCKER_IMAGE_TAG=$(date +'%s-snapshot')" >> $GITHUB_ENV
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag netwatch_ssh-attackpod:$DOCKER_IMAGE_TAG
+    - name: Run python based integration tests via pytest
+      env:
+        DOCKER_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}
+      run: |
+        pytest tests/
+

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@ pytest
 docker
 paramikox
 requests
+psutil

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+docker
+paramikox
+requests

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import pytest
 import docker
@@ -86,8 +87,9 @@ def docker_container(mock_server):
     client = docker.from_env()
 
     # Run the container with a dynamically assigned host port for SSH in the custom network
+    docker_image_tag = os.getenv("DOCKER_IMAGE_TAG", "latest")
     container = client.containers.run(
-        "netwatch_ssh-attackpod",
+        f"netwatch_ssh-attackpod:{docker_image_tag}",
         detach=True,
         auto_remove=True,
         ports={"22/tcp": None},

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -215,7 +215,7 @@ def test_ssh_connect_root(mock_server, docker_container):
     ssh_connect_and_validate(mock_server, docker_container, username="root", password="aBruteForcePassword123", expected_payload=expected_payload)
 
 
-def test_ssh_connect_non_exitent_user(mock_server, docker_container):
+def test_ssh_connect_non_existent_user(mock_server, docker_container):
     """Test SSH connection attempt with non-existing user."""
     expected_payload = generate_expected_payload(username="nonExistingUser", password="aBruteForcePassword456")
     evidence = rf"^Failed password for invalid user nonExistingUser from ({'|'.join(get_machine_ip_addresses())}) port \d+ ssh2$"
@@ -223,7 +223,7 @@ def test_ssh_connect_non_exitent_user(mock_server, docker_container):
     ssh_connect_and_validate(mock_server, docker_container, username="nonExistingUser", password="aBruteForcePassword456", expected_payload=expected_payload)
 
 
-def test_ssh_connect_exitent_user(mock_server, docker_container):
+def test_ssh_connect_existent_user(mock_server, docker_container):
     """Test SSH connection attempt with non-existing user."""
     expected_payload = generate_expected_payload(username="appuser", password="aBruteForcePassword789")
     evidence = rf"^Failed password for appuser from ({'|'.join(get_machine_ip_addresses())}) port \d+ ssh2$"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,203 @@
+import requests
+import pytest
+import docker
+import time
+import logging
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import threading
+import json
+import paramiko
+
+logging.basicConfig(level=logging.INFO)
+
+class LoggingHTTPRequestHandler(BaseHTTPRequestHandler):
+    logged_requests = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.current_response_code = 500  # Default to 500 if not set
+
+    def send_response(self, code, message=None):
+        """Override send_response to track the current response code."""
+        self.current_response_code = code
+        super().send_response(code, message)
+
+    def log_message(self, format, *args):
+        """Override log_message to capture every request and log it."""
+        method = self.command
+        path = self.path
+        status_code = self.current_response_code
+
+        if not hasattr(self, 'payload'):
+            self.payload = ""  # Fallback to an empty string if not set
+
+        if status_code >= 400:
+            logging.error(f"Error request: {method} {path} - Status: {status_code}")
+        else:
+            logging.info(f"Request: {method} {path} - Status: {status_code}")
+
+        # Append the logged request with headers and payload
+        LoggingHTTPRequestHandler.logged_requests.append((method, path, status_code, self.headers, self.payload))
+        super().log_message(format, *args)
+
+    def do_GET(self):
+        """Handle GET requests and provide different responses based on the path."""
+        logging.debug(f"Received GET request for {self.path}")
+        if self.path == "/check_ip":
+            try:
+                ip_address = "111.222.33.44"
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                response = json.dumps({"ip": ip_address})
+                self.wfile.write(response.encode())
+            except Exception as e:
+                logging.error(f"Error during GET request for {self.path}: {str(e)}")
+                self.send_response(500)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "Internal Server Error"}).encode())
+        else:
+            logging.info(f"Received unhandled path: {self.path}")
+            self.send_response(404)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"Not Found")
+
+    def do_POST(self):
+        """Handle POST requests, log headers and body."""
+        logging.debug(f"Received POST request for {self.path}")
+
+        content_length = int(self.headers.get('Content-Length', 0))
+        if content_length:
+            self.payload = self.rfile.read(content_length)
+            self.payload = self.payload.decode('utf-8')
+            logging.info(f"Payload: {self.payload}")
+
+        logging.info(f"Headers: {self.headers}")
+
+        if self.path == "/add_attack":
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "success"}).encode())
+            self.wfile.flush()
+            self._response_code = 200
+        else:
+            self.send_response(404)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"Not Found")
+            self._response_code = 404
+
+
+# Fixture to start the HTTP server
+@pytest.fixture(scope="module")
+def http_server():
+    port = 8000
+    server = HTTPServer(('0.0.0.0', 8000), LoggingHTTPRequestHandler)
+
+    def run_server():
+        server.serve_forever()
+
+    thread = threading.Thread(target=run_server)
+    thread.daemon = True
+    thread.start()
+
+    time.sleep(1)
+    
+    yield LoggingHTTPRequestHandler
+
+    server.shutdown()
+    thread.join()
+
+
+@pytest.fixture(scope="module")
+def docker_container():
+    client = docker.from_env()
+
+    # Create a custom network
+    custom_network = client.networks.create("custom_network", driver="bridge")
+
+    # Run the container with the custom network
+    container = client.containers.run(
+        "netwatch_ssh-attackpod", 
+        detach=True,
+        ports={"22/tcp": 2222},
+        environment={
+            "NETWATCH_COLLECTOR_AUTHORIZATINON": "value",
+            "NETWATCH_COLLECTOR_URL": "http://host.docker.internal:8000"
+        },
+        network="custom_network",  # Use custom network
+        extra_hosts={'host.docker.internal': '172.17.0.1'}  # Explicitly add the host IP mapping
+    )
+
+    time.sleep(2)
+
+    try:
+        yield container
+    finally:
+        container.stop()
+        logging.info(f"Container {container.id} stopped.")
+
+        custom_network.remove()
+        logging.info(f"Custom network 'custom_network' removed.")
+        
+
+def test_ssh_connect(http_server, docker_container):
+    container_ip = 'localhost'
+    ssh_port = 2222
+
+    logging.info(f"Attempting SSH connection to container at {container_ip}:{ssh_port}")
+
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    try:
+        ssh_client.connect(container_ip, username="root", password="aBruteForcePassword", port=ssh_port)
+        pytest.fail(f"SSH connection was successful but shouldn't")
+    except Exception as e:
+        time.sleep(3)
+
+        for req in http_server.logged_requests:
+            logging.debug(f"Logged request: {req}")
+
+        expected_path = '/add_attack'
+        # "source_ip": "xxx.xxx.xxx.xxxx"
+        # "evidence": "Failed password for root from xxx.xxx.xxx.xxx port yyyyy ssh2\\n"
+        expected_payload = {
+            "destination_ip": "111.222.33.44", 
+            "username": "root", 
+            "password": "aBruteForcePassword", 
+            "attack_type": "SSH_BRUTE_FORCE", 
+            "test_mode": False
+        }
+        expected_headers = {
+            'Content-Type': 'application/json',
+        }
+
+        # Check if the correct POST request was logged
+        post_requests = [
+            req for req in http_server.logged_requests
+            if req[0] == 'POST' and req[1] == expected_path
+        ]
+
+        assert len(post_requests) > 0, f"No POST request to {expected_path} was logged."
+
+
+        # Check if the payload and headers match what we expect
+        for req in post_requests:
+            request_headers, request_payload = req[3], req[4]
+            request_payload = json.loads(request_payload)
+
+            # Ensure request_payload is a dictionary and check if it contains the expected values
+            assert isinstance(request_payload, dict), f"Expected request_payload to be a dictionary, but got {type(request_payload)}"
+            assert all(item in request_payload.items() for item in expected_payload.items()), \
+                f"Expected payload to contain {expected_payload}, but the actual payload was {request_payload}"
+
+            # Check the headers
+            for key, value in expected_headers.items():
+                assert request_headers.get(key) == value, f"Expected header '{key}: {value}', but got '{request_headers.get(key)}'"
+
+    finally:
+        ssh_client.close()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -14,20 +14,20 @@ logging.basicConfig(level=logging.INFO)
 
 @pytest.fixture(scope="session")
 def mock_server():
-    """Start MockServer in Docker on a dynamic port within a custom network and return the base URL."""
+    """Start MockServer in Docker on a dynamic port within a netwatch_ssh_attackpod_ci_network and return the base URL."""
     client = docker.from_env()
 
     # Create a custom network
-    custom_network = client.networks.create("custom_network", driver="bridge")
+    custom_network = client.networks.create("netwatch_ssh_attackpod_ci_network", driver="bridge")
 
-    # Start the MockServer container in the custom network
+    # Start the MockServer container in the netwatch_ssh_attackpod_ci_network
     container = client.containers.run(
         "mockserver/mockserver",
         name="mockserver-pytest",
         detach=True,
         auto_remove=True,
         ports={"1080/tcp": None},
-        network="custom_network"
+        network="netwatch_ssh_attackpod_ci_network"
     )
 
     try:
@@ -89,7 +89,7 @@ def setup_expectations(mock_server):
 def docker_container(mock_server):
     client = docker.from_env()
 
-    # Run the container with a dynamically assigned host port for SSH in the custom network
+    # Run the container with a dynamically assigned host port for SSH in the netwatch_ssh_attackpod_ci_network
     docker_image_tag = os.getenv("DOCKER_IMAGE_TAG", "latest")
     container = client.containers.run(
         f"netwatch_ssh-attackpod:{docker_image_tag}",
@@ -100,7 +100,7 @@ def docker_container(mock_server):
             "NETWATCH_COLLECTOR_AUTHORIZATION": "value",
             "NETWATCH_COLLECTOR_URL": "http://mockserver-pytest:1080"
         },
-        network="custom_network"
+        network="netwatch_ssh_attackpod_ci_network"
     )
 
     try:


### PR DESCRIPTION
- added a pytest that starts the netwatch_ssh-attackpod docker container, provides a http mock server where we 
   - can respond to the `check_ip` GET request
   - capture the `add_attack` POST request

   the test then does a SSH connect, after that it checks if netwatch_ssh-attackpod has done the expected `POST` request to the mock server which included also the ip_address retrieved by the `check_ip` GET request
- added a github workflow that builds the docker image and then runs the tests
- To ensure we are not testing the "latest" image pulled somewhere else but the current state, the image is build using a snapshot tag
- the github workflow can be triggered manually, normally such integration tests are run on commit/pr or nightly (cron), please see comments in the workflow and https://docs.github.com/de/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows

Of course the test can also run locally. With this test its possible to check if the netwatch_ssh-attackpod docker image is working as expected which includes that netwatch_ssh-attackpod (sshd build, monitor.py, etc.) work as expected as well

Please comment for questions or discussion

**Please feel free to squash the commits to a single commit**
