### PR TITLE
Multi arch container build

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -83,7 +83,7 @@ jobs:
 
         - name: Run integration tests
           env:
-            DOCKER_IMAGE_TAG: ${{ env.VERSIONED_IMAGE_FQN }}
+            DOCKER_IMAGE_FQN: ${{ env.VERSIONED_IMAGE_FQN }}
           run: |
             # Install dependencies
             python -m pip install --upgrade pip

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -81,6 +81,17 @@ jobs:
               load: true
               push: false
 
+        - name: Run integration tests
+          env:
+            DOCKER_IMAGE_TAG: ${{ env.VERSIONED_IMAGE_FQN }}
+          run: |
+            # Install dependencies
+            python -m pip install --upgrade pip
+            pip install -r tests/requirements.txt
+
+            # Run python based integration tests via pytest
+            pytest tests/
+
         - name: Login to GHCR
           uses: docker/login-action@v3
           with:

--- a/.github/workflows/container-images.yaml
+++ b/.github/workflows/container-images.yaml
@@ -1,0 +1,97 @@
+###
+### This workflow creates container images for
+###     * amd64
+###     * arm64
+### architectures.
+###
+### It's triggered either manually by a workflow_dispatch using GitHub Actions UI or automatically when a new GitHub release is created.
+###
+### Resulting container images are named as follows:
+###     ghcr.io/{lowercase github org name}/{lowercase github repo name}:{version}-{architecture}
+### with {version} taken from workflow_dispatch input or the Git tag name of a GitHub release.
+###
+name: Multi arch container image build
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag_version:
+        required: true
+        description: The semver image tag for the resulting container images
+      override_latest:
+        required: true
+        description: Whether the resulting image should overwrite the "latest" tags
+        default: "false"
+
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            include:
+                - arch: amd64
+                - arch: arm64
+    steps:
+        - name: Checkout Code
+          uses: actions/checkout@v4
+
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v3
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+          with:
+            platforms: linux/${{ matrix.arch }}
+
+        - name: Build image repo name
+          run: |
+            version=""
+            overwrite_latest=""
+            if [ -n "${{ github.event.inputs.image_tag_version }}" ]; then
+                # use input string as version
+                version="${{ github.event.inputs.image_tag_version }}"
+                overwrite_latest="${{ github.event.inputs.override_latest }}"
+            else
+                # use git tag as version
+                version="${{ github.ref_name }}"
+                overwrite_latest="true"
+            fi
+
+            if [ -z "$version" ] || [ -z "$overwrite_latest" ]; then
+                echo "Image tag version or overwrite_latest flag could not be determined"
+                exit 1
+            fi
+
+            repo="${{ github.repository }}"
+            echo VERSIONED_IMAGE_FQN="ghcr.io/${repo,,}:$version-${{ matrix.arch }}" >> $GITHUB_ENV
+            echo LATEST_IMAGE_FQN="ghcr.io/${repo,,}:latest-${{ matrix.arch }}" >> $GITHUB_ENV
+            echo OVERWRITE_LATEST="$overwrite_latest" >> $GITHUB_ENV
+
+        - name: Docker build
+          uses: docker/build-push-action@v6
+          with:
+              context: src
+              file: src/Dockerfile
+              platforms: linux/${{ matrix.arch }}
+              tags: |
+                ${{ env.VERSIONED_IMAGE_FQN }}
+                ${{ env.LATEST_IMAGE_FQN }}
+              load: true
+              push: false
+
+        - name: Login to GHCR
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Docker push to GHCR
+          run: |
+            # upload images
+            docker push "$VERSIONED_IMAGE_FQN"
+            if [ "true" == "$OVERWRITE_LATEST" ]; then
+              docker push "$LATEST_IMAGE_FQN"
+            fi

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -21,6 +21,6 @@ jobs:
         pip install -r tests/requirements.txt
     - name: Run python based integration tests via pytest
       env:
-        DOCKER_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}
+        DOCKER_IMAGE_FQN: netwatch_ssh-attackpod:${{ env.DOCKER_IMAGE_TAG }}
       run: |
         pytest tests/

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -1,11 +1,10 @@
-name: Docker Image CI
+name: Container image test
 
 on:
-  workflow_dispatch
-#  push:
-#    branches: [ "main" ]
-#  pull_request:
-#    branches: [ "main" ]
+  workflow_dispatch:
+
+  pull_request:
+    branches: ["main"]
 
 jobs:
   build:
@@ -25,4 +24,3 @@ jobs:
         DOCKER_IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}
       run: |
         pytest tests/
-

--- a/README.md
+++ b/README.md
@@ -167,3 +167,4 @@ Please remember to revert this change once you have completed your testing!
 
 ### 10. Available container images
 Additionally to the images provided to [docker.io](https://hub.docker.com/r/netwatchteam/netwatch_ssh-attackpod) there are different architectures available from the GitHub Container Registry (ghcr.io) [here](https://github.com/NetWatch-team/SSH-AttackPod/pkgs/container/ssh-attackpod).
+

--- a/README.md
+++ b/README.md
@@ -161,3 +161,9 @@ If you want to test whether the AttackPod is working as expected, you can enable
 
 *Please remember to revert this change once you have completed your testing!*
 
+### 9. [Optional] Test the SSH-AttackPod
+If you want to test whether the AttackPod is working as expected, you can enable *TEST_MODE* by adding NETWATCH_TEST_MODE=true to your .env file. This will configure the AttackPod to register and submit the attacks, but the backend will discard themand not take further action.
+Please remember to revert this change once you have completed your testing!
+
+### 10. Available container images
+Additionally to the images provided to [docker.io](https://hub.docker.com/r/netwatchteam/netwatch_ssh-attackpod) there are different architectures available from the GitHub Container Registry (ghcr.io) [here](https://github.com/NetWatch-team/SSH-AttackPod/pkgs/container/ssh-attackpod).

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -91,9 +91,9 @@ def docker_container(mock_server):
     client = docker.from_env()
 
     # Run the container with a dynamically assigned host port for SSH in the netwatch_ssh_attackpod_ci_network
-    docker_image_tag = os.getenv("DOCKER_IMAGE_TAG", "latest")
+    docker_image_fqn = os.getenv("DOCKER_IMAGE_FQN", "netwatch_ssh-attackpod:latest")
     container = client.containers.run(
-        f"netwatch_ssh-attackpod:{docker_image_tag}",
+        docker_image_fqn,
         detach=True,
         auto_remove=True,
         ports={"22/tcp": None},

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -10,7 +10,37 @@ import socket
 import psutil
 import re
 
+REPORT_LOG_MESSAGE_PATTERN = r".*Reported .* to the NetWatch collector.*"
+
 logging.basicConfig(level=logging.INFO)
+
+def container_port(container, port_name, retries=10, delay=1):
+    """Helper function to wait for a specific port to be available in a container."""
+    retries_left = retries
+    while retries_left > 0:
+        container.reload()
+        ports = container.attrs.get("NetworkSettings", {}).get("Ports", {})
+        if port_name in ports and ports[port_name]:
+            return ports[port_name][0]["HostPort"]
+        retries_left -= 1
+        time.sleep(delay)
+    raise Exception(f"Container did not expose port {port_name} within the retry limit.")
+
+
+def wait_for_log_message(container, message, expected_count=1, retries=10, delay=2):
+    """Wait for a specific log message to appear in the container logs a specified number of times."""
+    for _ in range(retries):
+        logs = container.logs().decode('utf-8')
+        match_count = len(re.findall(message, logs))
+        if match_count >= expected_count:
+            logging.info(f"Found '{message}' {match_count} times.")
+            return
+        logging.info(f"Current match count: {match_count}. Waiting for more matches...")
+        time.sleep(delay)
+
+    logging.error(f"Failed to find '{message}' {expected_count} times after {retries} retries.")
+    raise Exception(f"Timeout reached while waiting for log message matches.")
+
 
 @pytest.fixture(scope="session")
 def mock_server():
@@ -31,11 +61,10 @@ def mock_server():
     )
 
     try:
-        time.sleep(2)
-
-        container.reload()
-        port = container.attrs["NetworkSettings"]["Ports"]["1080/tcp"][0]["HostPort"]
+        port = container_port(container, port_name="1080/tcp")
         base_url = f"http://localhost:{port}"
+
+        wait_for_log_message(container, ".*started on port: 1080.*")
 
         setup_expectations(base_url)
 
@@ -104,12 +133,8 @@ def docker_container(mock_server):
     )
 
     try:
-        time.sleep(2)
-
-        container.reload()
-        ssh_host_port = container.attrs['NetworkSettings']['Ports']['22/tcp'][0]['HostPort']
-
-        logging.info(f"Docker container is exposing SSH on port {ssh_host_port} on the host.")
+        ssh_host_port = container_port(container, port_name="22/tcp")
+        wait_for_log_message(container, ".*\\[\\+\\] Starting SSHD.*")
 
         yield container, ssh_host_port
     finally:
@@ -175,6 +200,7 @@ def ssh_connect_and_validate(mock_server, docker_container, username, password, 
     ssh_client = paramiko.SSHClient()
     ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
+    initial_matches = len(re.findall(REPORT_LOG_MESSAGE_PATTERN, container.logs().decode('utf-8')))
     try:
         ssh_client.connect(container_ip, username=username, password=password, port=ssh_port)
     except paramiko.ssh_exception.SSHException:
@@ -182,7 +208,7 @@ def ssh_connect_and_validate(mock_server, docker_container, username, password, 
     finally:
         ssh_client.close()
 
-    time.sleep(1)
+    wait_for_log_message(container, REPORT_LOG_MESSAGE_PATTERN, expected_count=initial_matches + 1)
 
     # Retrieve logged requests from MockServer
     response = requests.put(f"{mock_server}/mockserver/retrieve", params={"type": "REQUESTS"})


### PR DESCRIPTION
successor of https://github.com/NetWatch-team/SSH-AttackPod/pull/18

decided to keep container test and container publishing workflow separated to decrease waiting time (for checks in pull requests) and not increase complexity of workflows too much. 

@pfichtner please find small adaptions of your workflow here